### PR TITLE
Allow for user-defined sockets via options

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ class DtlsServer extends EventEmitter {
 		}, options);
 
 		this.sockets = {};
-		this.dgramSocket = dgram.createSocket('udp4');
+		this.dgramSocket = options.socket || dgram.createSocket('udp4');
 		this._onMessage = this._onMessage.bind(this);
 		this.listening = false;
 


### PR DESCRIPTION
In my particular case I need this for using `udp6` sockets.
The implementation mirrors the behavior of `node-mbed-dtls-client`.