### PR TITLE
Migrate to node-addon-api (N-API)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = tab
+indent_size = 4
+
+[*.{cc,h}]
+indent_style = tab
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 test
-foo.js
+**/*.test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+test
+foo.js

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,15 @@
   "targets": [
     {
       "target_name": "mbedtls",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "type": "static_library",
       "sources": [
         "mbedtls/library/debug.c",
@@ -24,6 +33,15 @@
     },
     {
       "target_name": "mbedx509",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "type": "static_library",
       "sources": [
         "mbedtls/library/certs.c",
@@ -46,6 +64,15 @@
     },
     {
       "target_name": "mbedcrypto",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "type": "static_library",
       "sources": [
         "mbedtls/library/aes.c",
@@ -110,6 +137,15 @@
     },
     {
       "target_name": "node_mbed_dtls",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "sources": [
         "src/init.cc",
         "src/DtlsServer.cc",
@@ -117,16 +153,18 @@
         "src/SessionWrap.cc"
       ],
       "include_dirs": [
-        "<!(node -e \"require('nan')\")",
+        "<!@(node -p \"require('node-addon-api').include\")",
         "mbedtls/include",
         "config"
       ],
       "dependencies": [
+        "<!(node -p \"require('node-addon-api').gyp\")",
         "mbedtls",
         "mbedx509",
         "mbedcrypto"
       ],
       "defines": [
+        "NAPI_DISABLE_CPP_EXCEPTIONS",
         "MBEDTLS_CONFIG_FILE=\"config-ecc-ccm-rpk-dtls1_2.h\""
       ]
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -164,7 +164,6 @@
         "mbedcrypto"
       ],
       "defines": [
-        "NAPI_DISABLE_CPP_EXCEPTIONS",
         "MBEDTLS_CONFIG_FILE=\"config-ecc-ccm-rpk-dtls1_2.h\""
       ]
     }

--- a/index.test.js
+++ b/index.test.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var path = require('path');
-var should = require('should');
-var sinon = require('sinon');
-var assert = require('assert');
+const path = require('path');
+const should = require('should');
+const sinon = require('sinon');
+const assert = require('assert');
 
-var dtls = require('../index');
+const dtls = require('./index');
 
 const opts = {
-	cert: path.join(__dirname, 'public.der'),
-	key: path.join(__dirname, 'private.der')
+	cert: path.join(__dirname, 'test/public.der'),
+	key: path.join(__dirname, 'test/private.der')
 };
 
 describe('createServer', function() {
@@ -49,17 +49,6 @@ describe('createServer', function() {
 		s2.listen(5683);
 	});
 });
-
-
-function check(f, done) {
-	try {
-		f();
-		done();
-	} catch (e) {
-		done(e);
-	}
-}
-
 
 function checkFinally(f, g, done) {
 	try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1153 @@
+{
+  "name": "node-mbed-dtls",
+  "version": "3.0.0-beta.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "node-addon-api": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
+      "integrity": "sha1-OZjUWT4tyi6oIRRnCk6wAzhqn+E="
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
+      "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha1-PxMnF88vnBaXJLK2yvNzz2lBmNs=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "should": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-7.1.1.tgz",
+      "integrity": "sha1-ZGTEi298Hh8YrASDV4+i3VXCxuA=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.5.0",
+        "should-format": "0.3.1",
+        "should-type": "0.2.0"
+      }
+    },
+    "should-equal": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
+      "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-format": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.1.tgz",
+      "integrity": "sha1-LLt4JGFnCs5CkrKx7EaNuM+Z4zA=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-type": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.0.tgz",
+      "integrity": "sha1-u149KbonA8et0K0zcAO+PKR3eYo=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mbed-dtls",
-  "version": "2.6.1",
+  "version": "3.0.0-beta.0",
   "description": "Node mbed DTLS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Node mbed DTLS",
   "main": "index.js",
   "scripts": {
-    "build": "node-gyp rebuild",
-    "debug": "node-gyp rebuild --debug",
+    "build": "node-gyp rebuild -j 8",
+    "debug": "node-gyp rebuild -j 8 --debug",
     "clean": "node-gyp clean",
     "install": "node-gyp rebuild",
     "test": "mocha test/server.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "node-gyp rebuild -j 8 --debug",
     "clean": "node-gyp clean",
     "install": "node-gyp rebuild",
-    "test": "mocha test/server.js"
+    "test": "mocha **/*.test.js"
   },
   "author": "Bryce Kahle",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "Apache-2.0",
   "gypfile": true,
   "dependencies": {
+    "bindings": "^1.5.0",
     "node-addon-api": "^1.6.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node-gyp rebuild",
+    "debug": "node-gyp rebuild --debug",
     "clean": "node-gyp clean",
     "install": "node-gyp rebuild",
     "test": "mocha test/server.js"

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "Node mbed DTLS",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/server.js",
+    "build": "node-gyp rebuild",
+    "clean": "node-gyp clean",
     "install": "node-gyp rebuild",
-    "build": "node-gyp build",
-    "start": "node index.js"
+    "test": "mocha test/server.js"
   },
   "author": "Bryce Kahle",
   "license": "Apache-2.0",
   "gypfile": true,
   "dependencies": {
-    "nan": "^2.0.9"
+    "node-addon-api": "^1.6.3"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ class DtlsServer extends EventEmitter {
 		// likely a PEM encoded key, add null terminating byte
 		// 0x2d = '-'
 		if (key[0] === 0x2d && key[key.length - 1] !== 0) {
-			key = Buffer.concat([key, new Buffer([0])]);
+			key = Buffer.concat([key, Buffer.from([0])]);
 		}
 
 		this.mbedServer = new mbed.DtlsServer(key, options.debug);
@@ -137,9 +137,9 @@ class DtlsServer extends EventEmitter {
 
 	_forceDeviceRehandshake(rinfo, deviceId){
 		this._debug(`Attemting force re-handshake by sending malformed hello request packet to deviceID=${deviceId}`);
-		
+
 		// Construct the 'session killing' Avada Kedavra packet
-		const malformedHelloRequest = new Buffer([
+		const malformedHelloRequest = Buffer.from([
 			0x16,                                 // Handshake message type 22
 			0xfe, 0xfd,                           // DTLS 1.2
 			0x00, 0x01,                           // Epoch

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var EventEmitter = require('events').EventEmitter;
 
 var DtlsSocket = require('./socket');
-var mbed = require('./build/Release/node_mbed_dtls');
+var mbed = require('bindings')('node_mbed_dtls.node');
 
 const APPLICATION_DATA_CONTENT_TYPE = 23;
 const IP_CHANGE_CONTENT_TYPE = 254;

--- a/server.js
+++ b/server.js
@@ -57,7 +57,7 @@ class DtlsServer extends EventEmitter {
 			this.once('close', callback);
 		}
 		this._closing = true;
-		this._endSockets();
+		this._closeSocket();
 	}
 
 	address() {
@@ -271,10 +271,6 @@ class DtlsServer extends EventEmitter {
 				s.end();
 			}
 		});
-
-		if (sockets.length === 0) {
-			this._closeSocket();
-		}
 	}
 
 	_socketClosed() {

--- a/server.js
+++ b/server.js
@@ -129,7 +129,7 @@ class DtlsServer extends EventEmitter {
 				this._debug(`Device in 'move session' lock state attempting to force it to re-handshake deviceID=${deviceId}`);
 
 				//Always EMIT this event instead of calling _forceDeviceRehandshake internally this allows the DS to device wether to send the packet or not to the device
-				this.emit('forceDeviceRehandshake', rinfo, deviceId); 
+				this.emit('forceDeviceRehandshake', rinfo, deviceId);
 			}
 		});
 		return lookedUp;
@@ -148,7 +148,7 @@ class DtlsServer extends EventEmitter {
 			0x00,                                 // HandshakeType hello_request
 			0x00                                  // Handshake body, intentionally too short at a single byte
 		]);
-		
+
 		// Sending the malformed hello request back over the raw UDP socket
 		this.dgramSocket.send(malformedHelloRequest, rinfo.port, rinfo.address);
 	}

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const path = require('path');
+const should = require('should');
+const sinon = require('sinon');
+const assert = require('assert');
+
+const dtls = require('./server');
+
+const opts = {
+	cert: path.join(__dirname, 'test/public.der'),
+	key: path.join(__dirname, 'test/private.der')
+};
+
+describe('server', function() {
+
+});

--- a/socket.js
+++ b/socket.js
@@ -2,7 +2,7 @@
 
 const stream = require('stream');
 
-const mbed = require('./build/Release/node_mbed_dtls');
+var mbed = require('bindings')('node_mbed_dtls.node');
 
 const MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY = -0x7880;
 const MBEDTLS_ERR_SSL_CLIENT_RECONNECT = -0x6780;

--- a/socket.test.js
+++ b/socket.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const path = require('path');
+const should = require('should');
+const sinon = require('sinon');
+const assert = require('assert');
+
+const dtls = require('./socket');
+
+describe('socket.js', function() {
+
+});

--- a/src/DtlsServer.cc
+++ b/src/DtlsServer.cc
@@ -54,8 +54,10 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 	}
 
 	Napi::Buffer<unsigned char> key_buffer = info[0].As<Napi::Buffer<unsigned char>>();
-	unsigned char * key = (unsigned char *) key_buffer.Data();
 	size_t key_len = key_buffer.Length();
+	unsigned char * key = (unsigned char *) malloc(key_len + 1);
+	memcpy(key, (unsigned char *) key_buffer.Data(), key_len);
+	key[key_len] = '\0';
 
 	int debug_level = 0;
 	if (info.Length() > 1) {
@@ -77,7 +79,8 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 	mbedtls_debug_set_threshold(debug_level);
 #endif
 
-	CHECK_MBEDTLS(mbedtls_pk_parse_key(&pkey, key, key_len, NULL, 0));
+	CHECK_MBEDTLS(mbedtls_pk_parse_key(&pkey, key, key_len + 1, NULL, 0));
+	free(key);
 	CHECK_MBEDTLS(mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, (const unsigned char *) pers, strlen(pers)));
 	CHECK_MBEDTLS(mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT));
 

--- a/src/DtlsServer.cc
+++ b/src/DtlsServer.cc
@@ -55,8 +55,7 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 
 	Napi::Buffer<unsigned char> key_buffer = info[0].As<Napi::Buffer<unsigned char>>();
 	size_t key_len = key_buffer.Length();
-	unsigned char * key = (unsigned char *) malloc(key_len);
-	memcpy(key, (unsigned char *) key_buffer.Data(), key_len);
+	unsigned char * key = key_buffer.Data();
 
 	int debug_level = 0;
 	if (info.Length() > 1) {
@@ -80,7 +79,6 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 
 	/** This, as is, will not work for PEM keys, only DER */
 	int parse_key_result = mbedtls_pk_parse_key(&pkey, key, key_len, NULL, 0);
-	free(key);
 	CHECK_MBEDTLS(parse_key_result);
 
 	CHECK_MBEDTLS(mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, (const unsigned char *) pers, strlen(pers)));

--- a/src/DtlsServer.cc
+++ b/src/DtlsServer.cc
@@ -114,12 +114,12 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 
 Napi::Value DtlsServer::GetHandshakeTimeoutMin(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-	return Napi::Number::New(env, this->handshake_timeout_min);
+	return Napi::Number::New(env, this->config()->hs_timeout_min);
 }
 
 void DtlsServer::SetHandshakeTimeoutMin(const Napi::CallbackInfo& info, const Napi::Value& value) {
-	this->handshake_timeout_min = value.As<Napi::Number>().Uint32Value();
-	mbedtls_ssl_conf_handshake_timeout(this->config(), this->handshake_timeout_min, this->config()->hs_timeout_max);
+	uint32_t hs_timeout_min = value.As<Napi::Number>().Uint32Value();
+	mbedtls_ssl_conf_handshake_timeout(this->config(), hs_timeout_min, this->config()->hs_timeout_max);
 }
 
 DtlsServer::~DtlsServer() {

--- a/src/DtlsServer.cc
+++ b/src/DtlsServer.cc
@@ -55,9 +55,8 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 
 	Napi::Buffer<unsigned char> key_buffer = info[0].As<Napi::Buffer<unsigned char>>();
 	size_t key_len = key_buffer.Length();
-	unsigned char * key = (unsigned char *) malloc(key_len + 1);
+	unsigned char * key = (unsigned char *) malloc(key_len);
 	memcpy(key, (unsigned char *) key_buffer.Data(), key_len);
-	key[key_len] = '\0';
 
 	int debug_level = 0;
 	if (info.Length() > 1) {
@@ -79,8 +78,11 @@ DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsSe
 	mbedtls_debug_set_threshold(debug_level);
 #endif
 
-	CHECK_MBEDTLS(mbedtls_pk_parse_key(&pkey, key, key_len + 1, NULL, 0));
+	/** This, as is, will not work for PEM keys, only DER */
+	int parse_key_result = mbedtls_pk_parse_key(&pkey, key, key_len, NULL, 0);
 	free(key);
+	CHECK_MBEDTLS(parse_key_result);
+
 	CHECK_MBEDTLS(mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, (const unsigned char *) pers, strlen(pers)));
 	CHECK_MBEDTLS(mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT));
 

--- a/src/DtlsServer.cc
+++ b/src/DtlsServer.cc
@@ -6,8 +6,6 @@
 #define mbedtls_printf     printf
 #define mbedtls_fprintf    fprintf
 
-using namespace node;
-
 static void my_debug( void *ctx, int level,
 											const char *file, int line,
 											const char *str )
@@ -22,48 +20,41 @@ static void my_debug( void *ctx, int level,
 	fflush((FILE *) ctx);
 }
 
-Nan::Persistent<v8::FunctionTemplate> DtlsServer::constructor;
+Napi::FunctionReference DtlsServer::constructor;
 
-void
-DtlsServer::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
-	Nan::HandleScope scope;
+Napi::Object DtlsServer::Initialize(Napi::Env env, Napi::Object exports) {
+	Napi::HandleScope scope(env);
 
-	// Constructor
-	v8::Local<v8::FunctionTemplate> ctor = Nan::New<v8::FunctionTemplate>(DtlsServer::New);
-	constructor.Reset(ctor);
-	v8::Local<v8::ObjectTemplate>	ctorInst = ctor->InstanceTemplate();
-	ctorInst->SetInternalFieldCount(1);
-	ctor->SetClassName(Nan::New("DtlsServer").ToLocalChecked());
+	Napi::Function func = DefineClass(env, "DtlsServer", {
+		InstanceAccessor("handshakeTimeoutMin", &DtlsServer::GetHandshakeTimeoutMin, &DtlsServer::SetHandshakeTimeoutMin),
+	});
 
-	Nan::SetAccessor(ctorInst, Nan::New("handshakeTimeoutMin").ToLocalChecked(), 0, SetHandshakeTimeoutMin);
+	constructor = Napi::Persistent(func);
+	constructor.SuppressDestruct();
 
-	Nan::Set(target, Nan::New("DtlsServer").ToLocalChecked(), ctor->GetFunction());
+	exports.Set("DtlsServer", func);
+
+	return exports;
 }
 
-void DtlsServer::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-	if (info.Length() < 1 ||
-			!Buffer::HasInstance(info[0])) {
-		return Nan::ThrowTypeError("Expecting key to be a buffer");
+DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsServer>(info) {
+	Napi::Env env = info.Env();
+
+	// Required 1st param: key
+	if (info.Length() < 1 || !info[0].IsBuffer()) {
+		Napi::TypeError::New(env, "Expecting first parameter (key) to be a buffer").ThrowAsJavaScriptException();
+		return;
 	}
 
-	size_t key_len = Buffer::Length(info[0]);
-
-	const unsigned char *key = (const unsigned char *)Buffer::Data(info[0]);
+	Napi::Buffer<unsigned char> key_buffer = info[0].As<Napi::Buffer<unsigned char>>();
+	unsigned char * key = (unsigned char *) key_buffer.Data();
+	size_t key_len = key_buffer.Length();
 
 	int debug_level = 0;
 	if (info.Length() > 1) {
-		debug_level = info[1]->Uint32Value();
+		debug_level = info[1].ToNumber().Uint32Value();
 	}
 
-	DtlsServer *server = new DtlsServer(key, key_len, debug_level);
-	server->Wrap(info.This());
-	info.GetReturnValue().Set(info.This());
-}
-
-DtlsServer::DtlsServer(const unsigned char *srv_key,
-											 size_t srv_key_len,
-											 int debug_level)
-		: Nan::ObjectWrap() {
 	int ret;
 	const char *pers = "dtls_server";
 	mbedtls_ssl_config_init(&conf);
@@ -80,71 +71,55 @@ DtlsServer::DtlsServer(const unsigned char *srv_key,
 	mbedtls_debug_set_threshold(debug_level);
 #endif
 
-	ret = mbedtls_pk_parse_key(&pkey,
-														 (const unsigned char *)srv_key,
-														 srv_key_len,
-														 NULL,
-														 0);
-	if (ret != 0) goto exit;
+	try {
+		ret = mbedtls_pk_parse_key(&pkey, key, key_len, NULL, 0);
+		if (ret) throw ret;
 
-	// TODO re-use node entropy and randomness
-	ret = mbedtls_ctr_drbg_seed(&ctr_drbg,
-															mbedtls_entropy_func,
-															&entropy,
-															(const unsigned char *) pers,
-															strlen(pers));
-	if (ret != 0) goto exit;
+		// TODO re-use node entropy and randomness
+		ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, (const unsigned char *) pers, strlen(pers));
+		if (ret) throw ret;
 
-	ret = mbedtls_ssl_config_defaults(&conf,
-																		MBEDTLS_SSL_IS_SERVER,
-																		MBEDTLS_SSL_TRANSPORT_DATAGRAM,
-																		MBEDTLS_SSL_PRESET_DEFAULT);
-	if (ret != 0) goto exit;
+		ret = mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT);
+		if (ret) throw ret;
 
-	mbedtls_ssl_conf_min_version(&conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+		mbedtls_ssl_conf_min_version(&conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
 
-	// TODO use node random number generator?
-	mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
-	mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
+		// TODO use node random number generator?
+		mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
+		mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
-	ret = mbedtls_ssl_conf_own_cert(&conf, &srvcert, &pkey);
-	if (ret != 0) goto exit;
+		ret = mbedtls_ssl_conf_own_cert(&conf, &srvcert, &pkey);
+		if (ret) throw ret;
 
-	ret = mbedtls_ssl_cookie_setup(&cookie_ctx,
-																 mbedtls_ctr_drbg_random,
-																 &ctr_drbg);
-	if (ret != 0) goto exit;
+		ret = mbedtls_ssl_cookie_setup(&cookie_ctx, mbedtls_ctr_drbg_random, &ctr_drbg);
+		if (ret) throw ret;
 
-	mbedtls_ssl_conf_dtls_cookies(&conf,
-																mbedtls_ssl_cookie_write,
-																mbedtls_ssl_cookie_check, 
-																&cookie_ctx);
+		mbedtls_ssl_conf_dtls_cookies(&conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &cookie_ctx);
 
-	// needed for server to send CertificateRequest
-	mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+		// needed for server to send CertificateRequest
+		mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
 
-	static int ssl_cert_types[] = { MBEDTLS_TLS_CERT_TYPE_RAW_PUBLIC_KEY, MBEDTLS_TLS_CERT_TYPE_NONE };
-	mbedtls_ssl_conf_client_certificate_types(&conf, ssl_cert_types);
-	mbedtls_ssl_conf_server_certificate_types(&conf, ssl_cert_types);
+		static int ssl_cert_types[] = { MBEDTLS_TLS_CERT_TYPE_RAW_PUBLIC_KEY, MBEDTLS_TLS_CERT_TYPE_NONE };
+		mbedtls_ssl_conf_client_certificate_types(&conf, ssl_cert_types);
+		mbedtls_ssl_conf_server_certificate_types(&conf, ssl_cert_types);
 
-	// turn off server sending Certificate
-	mbedtls_ssl_conf_certificate_send(&conf, MBEDTLS_SSL_SEND_CERTIFICATE_DISABLED);
-
-	return;
-exit:
-	throwError(ret);
-	return;
+		// turn off server sending Certificate
+		mbedtls_ssl_conf_certificate_send(&conf, MBEDTLS_SSL_SEND_CERTIFICATE_DISABLED);
+	} catch (int ret) {
+		char error_buf[255];
+		mbedtls_strerror(ret, error_buf, 255);
+		Napi::Error::New(env, error_buf).ThrowAsJavaScriptException();
+	}
 }
 
-NAN_SETTER(DtlsServer::SetHandshakeTimeoutMin) {
-	DtlsServer *server = Nan::ObjectWrap::Unwrap<DtlsServer>(info.This());
-	mbedtls_ssl_conf_handshake_timeout(server->config(), value->Uint32Value(), server->config()->hs_timeout_max);
+Napi::Value DtlsServer::GetHandshakeTimeoutMin(const Napi::CallbackInfo& info) {
+	Napi::Env env = info.Env();
+	return Napi::Number::New(env, this->handshake_timeout_min);
 }
 
-void DtlsServer::throwError(int ret) {
-	char error_buf[100];
-	mbedtls_strerror(ret, error_buf, 100);
-	Nan::ThrowError(error_buf);
+void DtlsServer::SetHandshakeTimeoutMin(const Napi::CallbackInfo& info, const Napi::Value& value) {
+	this->handshake_timeout_min = value.As<Napi::Number>().Uint32Value();
+	mbedtls_ssl_conf_handshake_timeout(this->config(), this->handshake_timeout_min, this->config()->hs_timeout_max);
 }
 
 DtlsServer::~DtlsServer() {

--- a/src/DtlsServer.cc
+++ b/src/DtlsServer.cc
@@ -45,6 +45,7 @@ Napi::Object DtlsServer::Initialize(Napi::Env env, Napi::Object exports) {
 
 DtlsServer::DtlsServer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DtlsServer>(info) {
 	Napi::Env env = info.Env();
+	Napi::HandleScope scope(env);
 
 	// Required 1st param: key
 	if (info.Length() < 1 || !info[0].IsBuffer()) {

--- a/src/DtlsServer.h
+++ b/src/DtlsServer.h
@@ -1,8 +1,7 @@
 #ifndef __DTLS_SERVER_H__
 #define __DTLS_SERVER_H__
 
-#include <node.h>
-#include <nan.h>
+#include <napi.h>
 
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
@@ -17,21 +16,15 @@
 #include "mbedtls/ssl_cache.h"
 #endif
 
-class DtlsServer : public Nan::ObjectWrap {
+class DtlsServer : public Napi::ObjectWrap<DtlsServer> {
 public:
-	static Nan::Persistent<v8::FunctionTemplate> constructor;
-	static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
-	static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static NAN_SETTER(SetHandshakeTimeoutMin);
-	DtlsServer(const unsigned char *srv_key,
-						 size_t srv_key_len,
-						 int debug_level = 0);
+	static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
 	inline mbedtls_ssl_config* config() { return &conf; }
-
-private:
-	void throwError(int ret);
+	DtlsServer(const Napi::CallbackInfo& info);
 	~DtlsServer();
-
+private:
+	static Napi::FunctionReference constructor;
+	uint32_t handshake_timeout_min;
 	mbedtls_ssl_cookie_ctx cookie_ctx;
 	mbedtls_entropy_context entropy;
 	mbedtls_ctr_drbg_context ctr_drbg;
@@ -41,7 +34,8 @@ private:
 #if defined(MBEDTLS_SSL_CACHE_C)
 	mbedtls_ssl_cache_context cache;
 #endif
-
+	void SetHandshakeTimeoutMin(const Napi::CallbackInfo& info, const Napi::Value& value);
+	Napi::Value GetHandshakeTimeoutMin(const Napi::CallbackInfo& info);
 };
 
 #endif

--- a/src/DtlsServer.h
+++ b/src/DtlsServer.h
@@ -16,6 +16,16 @@
 #include "mbedtls/ssl_cache.h"
 #endif
 
+#define CHECK_MBEDTLS(_expr) \
+	do { \
+		const int _r = _expr; \
+		if (_r != 0) { \
+			throwMbedTlsError(env, _r); \
+		} \
+	} while (false)
+
+void throwMbedTlsError(Napi::Env& env, int error);
+
 class DtlsServer : public Napi::ObjectWrap<DtlsServer> {
 public:
 	static Napi::Object Initialize(Napi::Env env, Napi::Object exports);

--- a/src/DtlsServer.h
+++ b/src/DtlsServer.h
@@ -24,7 +24,6 @@ public:
 	~DtlsServer();
 private:
 	static Napi::FunctionReference constructor;
-	uint32_t handshake_timeout_min;
 	mbedtls_ssl_cookie_ctx cookie_ctx;
 	mbedtls_entropy_context entropy;
 	mbedtls_ctr_drbg_context ctr_drbg;

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -194,10 +194,11 @@ DtlsSocket::DtlsSocket(const Napi::CallbackInfo& info) :
 		env(info.Env()) {
 	DtlsServer *server = Napi::ObjectWrap<DtlsServer>::Unwrap(info[0].As<Napi::Object>());
 	std::string client_ip = (std::string) info[1].As<Napi::String>();
-	send_cb = info[2].As<Napi::Function>();
-	error_cb = info[3].As<Napi::Function>();
-	handshake_cb = info[4].As<Napi::Function>();
-	resume_sess_cb = info[5].As<Napi::Function>();
+
+	send_cb = Napi::Persistent(info[2].As<Napi::Function>());
+	error_cb = Napi::Persistent(info[3].As<Napi::Function>());
+	handshake_cb = Napi::Persistent(info[4].As<Napi::Function>());
+	resume_sess_cb = Napi::Persistent(info[5].As<Napi::Function>());
 	session_wait = false;
 	int ret;
 

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -72,7 +72,7 @@ Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 	unsigned char buf[len];
 	len = socket->receive_data(buf, len);
 
-	return len > 0 ? Napi::Buffer<unsigned char>::Copy(env, buf, len) : Napi::Object::New(env);
+	return len > 0 ? Napi::Buffer<unsigned char>::Copy(env, buf, len) : env.Undefined();
 }
 
 Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -93,7 +93,7 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 	}
 
 	// key is written at the end
-	return Napi::Buffer<char>::Copy(env, (char *)buf + (KEY_BUF_LENGTH - ret), ret);
+	return Napi::Buffer<unsigned char>::Copy(env, buf + (KEY_BUF_LENGTH - ret), ret);
 }
 
 Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
@@ -112,12 +112,12 @@ Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
 		return env.Undefined();
 	}
 
-	return Napi::Buffer<char>::Copy(env, (char *)buf, strlen((char *)buf));
+	return Napi::Buffer<unsigned char>::Copy(env, buf, strlen((char *) buf));
 }
 
 Napi::Value DtlsSocket::GetOutCounter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-	return Napi::Buffer<char>::Copy(env, (char *) ssl_context.out_ctr, 8);
+	return Napi::Buffer<unsigned char>::Copy(env, ssl_context.out_ctr, 8);
 }
 
 Napi::Value DtlsSocket::GetSession(const Napi::CallbackInfo& info) {
@@ -287,7 +287,7 @@ void DtlsSocket::reset() {
 
 int DtlsSocket::send_encrypted(const unsigned char *buf, size_t len) {
 	send_cb.Call({
-		Napi::Buffer<char>::Copy(env, (char *)buf, len)
+		Napi::Buffer<unsigned char>::Copy(env, (unsigned char *)buf, len)
 	});
 
 	return len;

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -426,6 +426,7 @@ int DtlsSocket::step() {
 			return 0;
 		} else if (ret != 0) {
 			// bad things
+			mbedtls_ssl_session_reset(&ssl_context);
 			error(ret);
 			return 0;
 		}

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -21,10 +21,10 @@ Napi::Value DtlsSocket::Initialize(Napi::Env& env, Napi::Object& exports) {
 		InstanceMethod("send", &DtlsSocket::Send),
 		InstanceMethod("resumeSession", &DtlsSocket::ResumeSession),
 		InstanceMethod("renegotiate", &DtlsSocket::Renegotiate),
-		InstanceAccessor("publicKey", &DtlsSocket::GetPublicKey, &DtlsSocket::NopSet),
-		InstanceAccessor("publicKeyPEM", &DtlsSocket::GetPublicKeyPEM, &DtlsSocket::NopSet),
-		InstanceAccessor("outCounter", &DtlsSocket::GetOutCounter, &DtlsSocket::NopSet),
-		InstanceAccessor("session", &DtlsSocket::GetSession, &DtlsSocket::NopSet),
+		InstanceAccessor("publicKey", &DtlsSocket::GetPublicKey, nullptr),
+		InstanceAccessor("publicKeyPEM", &DtlsSocket::GetPublicKeyPEM, nullptr),
+		InstanceAccessor("outCounter", &DtlsSocket::GetOutCounter, nullptr),
+		InstanceAccessor("session", &DtlsSocket::GetSession, nullptr),
 	});
 
 	constructor = Napi::Persistent(func);

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -38,6 +38,8 @@ Napi::Value DtlsSocket::Initialize(Napi::Env& env, Napi::Object& exports) {
 
 Napi::Object DtlsSocket::New(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
+	Napi::EscapableHandleScope scope(env);
+
 	if (info.Length() < 6) {
 		throw Napi::TypeError::New(env, "DtlsSocket requires six arguments");
 	}
@@ -53,7 +55,7 @@ Napi::Object DtlsSocket::New(const Napi::CallbackInfo& info) {
 
 	Napi::Object obj = constructor.New({ server, client_ip, send_cb, hs_cb, error_cb, resume_cb });
 
-	return obj;
+	return scope.Escape(napi_value(obj)).ToObject();
 }
 
 Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -15,7 +15,7 @@ Napi::Value DtlsSocket::Initialize(Napi::Env& env, Napi::Object& exports) {
 	Napi::HandleScope scope(env);
 
 	// Constructor
-	Napi::Function func = DefineClass(env, "SessionWrap", {
+	Napi::Function func = DefineClass(env, "DtlsSocket", {
 		InstanceMethod("receiveData", &DtlsSocket::ReceiveDataFromNode),
 		InstanceMethod("close", &DtlsSocket::Close),
 		InstanceMethod("send", &DtlsSocket::Send),

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -72,13 +72,6 @@ Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 	unsigned char buf[RECV_BUF_LENGTH];
 	memset(buf, 0, RECV_BUF_LENGTH); // just to see what is going on in the debug prints
 	unsigned int len = receive_data(buf, RECV_BUF_LENGTH);
-	dump_char_data("Recv", buf, RECV_BUF_LENGTH);
-
-	if (len > 0) {
-		printf("--- SET RESULT TO BUFFER COPY WITH LEN=%d\n", len);
-	} else {
-		printf("--- SET RESULT TO UNDEFINED\n");
-	}
 
 	return len > 0 ? Napi::Buffer<unsigned char>::Copy(env, buf, len) : env.Undefined();
 }
@@ -422,7 +415,6 @@ int DtlsSocket::step() {
 			return 0;
 		} else if (ret != 0) {
 			// bad things
-			mbedtls_ssl_session_reset(&ssl_context);
 			error(ret);
 			return 0;
 		}

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -82,17 +82,17 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 	if (session == NULL) {
 		throw Napi::TypeError::New(env, "ssl_context.session was null");
 	}
-	int ret;
-	const size_t buf_len = 256;
-	unsigned char buf[buf_len];
+
+	unsigned char buf[KEYBUFF_LENGTH];
 	mbedtls_pk_context pk = session->peer_cert->pk;
-	ret = mbedtls_pk_write_pubkey_der(&pk, buf, buf_len);
+	int ret = mbedtls_pk_write_pubkey_der(&pk, buf, KEYBUFF_LENGTH);
+
 	if (ret < 0) {
-		throw Napi::TypeError::New(env, "error in mbedtls_pk_write_pubkey_der");
+		throw Napi::TypeError::New(env, "error at mbedtls_pk_write_pubkey_der");
 	}
 
 	// key is written at the end
-	return Napi::Buffer<char>::Copy(env, (char *)buf + (buf_len - ret), ret);
+	return Napi::Buffer<char>::Copy(env, (char *)buf + (KEYBUFF_LENGTH - ret), ret);
 }
 
 Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
@@ -105,17 +105,15 @@ Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
 		throw Napi::TypeError::New(env, "ssl_context.session was null");
 	}
 
-	int ret;
-	const size_t buf_len = 256;
-	unsigned char buf[buf_len];
+	unsigned char buf[KEYBUFF_LENGTH];
 	mbedtls_pk_context pk = session->peer_cert->pk;
-	ret = mbedtls_pk_write_pubkey_pem(&pk, buf, buf_len);
+	int ret = mbedtls_pk_write_pubkey_pem(&pk, buf, KEYBUFF_LENGTH);
+
 	if (ret < 0) {
-		const char * message =  "error at mbedtls_pk_write_pubkey_pem";
-		return Napi::Buffer<const char>::Copy(env, message, strlen(message));
+		throw Napi::TypeError::New(env, "error at mbedtls_pk_write_pubkey_pem");
 	}
 
-	return Napi::Buffer<const char>::Copy(env, (char *)buf, strlen((const char *)buf));
+	return Napi::Buffer<char>::Copy(env, (char *)buf, strlen((char *)buf));
 }
 
 Napi::Value DtlsSocket::GetOutCounter(const Napi::CallbackInfo& info) {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -440,8 +440,8 @@ void DtlsSocket::throwError(int ret) {
 }
 
 void DtlsSocket::error(int ret) {
-	char error_buf[100];
-	mbedtls_strerror(ret, error_buf, 100);
+	char error_buf[255];
+	mbedtls_strerror(ret, error_buf, 255);
 
 	error_cb.Call({
 		Napi::Number::New(env, ret),

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -316,7 +316,7 @@ int DtlsSocket::send(const unsigned char *buf, size_t len) {
 	return ret;
 }
 
-int DtlsSocket::receive_data(unsigned char *buf, int len) {
+int DtlsSocket::receive_data(unsigned char *buf, size_t len) {
 	int ret;
 
 	if (ssl_context.state == MBEDTLS_SSL_HANDSHAKE_OVER) {
@@ -441,15 +441,20 @@ void DtlsSocket::error(int ret) {
 	});
 }
 
-void DtlsSocket::store_data(const unsigned char *buf, size_t len) {
+int DtlsSocket::store_data(const unsigned char *buf, size_t len) {
 	if (recv_buf == nullptr) {
 		recv_buf = (unsigned char *) malloc(len);
 	} else if (recv_len < len) {
 		recv_buf = (unsigned char *) realloc(recv_buf, len);
 	}
 
+	if (recv_buf == nullptr) {
+		return 0;
+	}
+
 	memcpy(recv_buf, buf, len);
 	recv_len = len;
+	return len;
 }
 
 int DtlsSocket::close() {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -39,8 +39,7 @@ Napi::Value DtlsSocket::Initialize(Napi::Env& env, Napi::Object& exports) {
 Napi::Object DtlsSocket::New(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
 	if (info.Length() < 6) {
-		Napi::TypeError::New(env, "DtlsSocket requires six arguments").ThrowAsJavaScriptException();
-		return Napi::Object::New(env);
+		throw Napi::TypeError::New(env, "DtlsSocket requires six arguments");
 	}
 
 	// TODO check arguments types
@@ -81,8 +80,7 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 
 	mbedtls_ssl_session *session = socket->ssl_context.session;
 	if (session == NULL) {
-		Napi::TypeError::New(env, "ssl_context.session was null").ThrowAsJavaScriptException();
-		return Napi::Object::New(env);
+		throw Napi::TypeError::New(env, "ssl_context.session was null");
 	}
 	int ret;
 	const size_t buf_len = 256;
@@ -90,8 +88,7 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 	mbedtls_pk_context pk = session->peer_cert->pk;
 	ret = mbedtls_pk_write_pubkey_der(&pk, buf, buf_len);
 	if (ret < 0) {
-		Napi::TypeError::New(env, "error in mbedtls_pk_write_pubkey_der").ThrowAsJavaScriptException();
-		return Napi::Object::New(env);
+		throw Napi::TypeError::New(env, "error in mbedtls_pk_write_pubkey_der");
 	}
 
 	// key is written at the end
@@ -105,8 +102,7 @@ Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
 	mbedtls_ssl_session *session = socket->ssl_context.session;
 	if (session == NULL ||
 		session->peer_cert == NULL) {
-		Napi::TypeError::New(env, "ssl_context.session was null").ThrowAsJavaScriptException();
-		return Napi::Object::New(env);
+		throw Napi::TypeError::New(env, "ssl_context.session was null");
 	}
 
 	int ret;
@@ -160,8 +156,7 @@ Napi::Value DtlsSocket::ResumeSession(const Napi::CallbackInfo& info) {
 
 	Napi::Object sessWrap = info[0].As<Napi::Object>();
 	if (sessWrap.IsEmpty()) {
-		Napi::TypeError::New(env, "ResumeSession requires one argument, was null").ThrowAsJavaScriptException();
-		return Napi::Object::New(env);
+		throw Napi::TypeError::New(env, "ResumeSession requires one argument, was null");
 	}
 
 	SessionWrap *sess = Napi::ObjectWrap<SessionWrap>::Unwrap(sessWrap);
@@ -444,7 +439,7 @@ int DtlsSocket::step() {
 void DtlsSocket::throwError(int ret) {
 	char error_buf[100];
 	mbedtls_strerror(ret, error_buf, 100);
-	Napi::Error::New(env, error_buf).ThrowAsJavaScriptException();
+	throw Napi::Error::New(env, error_buf);
 }
 
 void DtlsSocket::error(int ret) {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -438,14 +438,14 @@ int DtlsSocket::step() {
 }
 
 void DtlsSocket::throwError(int ret) {
-	char error_buf[100];
-	mbedtls_strerror(ret, error_buf, 100);
+	char error_buf[255];
+	mbedtls_strerror(ret, error_buf, 254);
 	throw Napi::Error::New(env, error_buf);
 }
 
 void DtlsSocket::error(int ret) {
 	char error_buf[255];
-	mbedtls_strerror(ret, error_buf, 255);
+	mbedtls_strerror(ret, error_buf, 254);
 
 	error_cb.Call({
 		Napi::Number::New(env, ret),

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -70,8 +70,8 @@ Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 	}
 
 	unsigned char buf[RECV_BUF_LENGTH];
-	memset(buf, 0, RECV_BUF_LENGTH); // just to see what is going on in the debug prints
-	unsigned int len = receive_data(buf, RECV_BUF_LENGTH);
+	memset(buf, 0, RECV_BUF_LENGTH);
+	size_t len = receive_data(buf, RECV_BUF_LENGTH);
 
 	return len > 0 ? Napi::Buffer<unsigned char>::Copy(env, buf, len) : env.Undefined();
 }

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -293,11 +293,10 @@ void DtlsSocket::reset() {
 }
 
 int DtlsSocket::send_encrypted(const unsigned char *buf, size_t len) {
-	napi_value  argv[] = {
+	send_cb.Call({
 		Napi::Buffer<char>::Copy(env, (char *)buf, len)
-	};
+	});
 
-	send_cb.Call(1, argv);
 	return len;
 }
 
@@ -345,11 +344,9 @@ int DtlsSocket::receive_data(unsigned char *buf, int len) {
 void DtlsSocket::get_session_cache(mbedtls_ssl_session *session) {
 	session_wait = true;
 
-	napi_value argv[] = {
+	resume_sess_cb.Call({
 		Napi::String::New(env, (const char*) session->id, session->id_len)
-	};
-
-	resume_sess_cb.Call(1, argv);
+	});
 }
 
 void DtlsSocket::renegotiate(SessionWrap *sess) {
@@ -432,8 +429,7 @@ int DtlsSocket::step() {
 	}
 
 	// this should only be called once when we first finish the handshake
-	napi_value argv[] = {};
-	handshake_cb.Call(0, argv);
+	handshake_cb.Call({});
 	return 0;
 }
 
@@ -446,12 +442,11 @@ void DtlsSocket::throwError(int ret) {
 void DtlsSocket::error(int ret) {
 	char error_buf[100];
 	mbedtls_strerror(ret, error_buf, 100);
-	napi_value argv[] = {
+
+	error_cb.Call({
 		Napi::Number::New(env, ret),
 		Napi::String::New(env, error_buf)
-	};
-
-	error_cb.Call(2, argv);
+	});
 }
 
 void DtlsSocket::store_data(const unsigned char *buf, size_t len) {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -40,10 +40,8 @@ Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 	Napi::HandleScope scope(env);
 
 	if (info.Length() >= 1 && info[0].IsBuffer()) {
-		Napi::Buffer<unsigned char> recv_buffer = info[0].As<Napi::Buffer<unsigned char>>();
-		const unsigned char *recv_data = (unsigned char *) recv_buffer.Data();
-		size_t recv_len = recv_buffer.Length();
-		store_data(recv_data, recv_len);
+		Napi::Buffer<unsigned char> recv = info[0].As<Napi::Buffer<unsigned char>>();
+		store_data(reinterpret_cast<unsigned char *>(recv.Data()), recv.Length());
 	}
 
 	unsigned char buf[RECV_BUF_LENGTH];
@@ -112,11 +110,8 @@ Napi::Value DtlsSocket::Close(const Napi::CallbackInfo& info) {
 
 Napi::Value DtlsSocket::Send(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-
-	Napi::Buffer<unsigned char> send_data_buffer = info[0].As<Napi::Buffer<unsigned char>>();
-	const unsigned char *send_data = (const unsigned char *) send_data_buffer.Data();
-	int ret = send(send_data, send_data_buffer.Length());
-
+	Napi::Buffer<unsigned char> buf = info[0].As<Napi::Buffer<unsigned char>>();
+	int ret = send(buf.Data(), buf.Length());
 	return Napi::Number::New(env, ret);
 }
 

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -58,6 +58,8 @@ Napi::Object DtlsSocket::New(const Napi::CallbackInfo& info) {
 
 Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
+	Napi::HandleScope scope(env);
+
 	DtlsSocket *socket = Napi::ObjectWrap<DtlsSocket>::Unwrap(info.This().As<Napi::Object>());
 
 	if (info.Length() >= 1 && info[0].IsBuffer()) {

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -35,29 +35,6 @@ Napi::Value DtlsSocket::Initialize(Napi::Env& env, Napi::Object& exports) {
 	return exports;
 }
 
-
-Napi::Object DtlsSocket::New(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
-
-	if (info.Length() < 6) {
-		throw Napi::TypeError::New(env, "DtlsSocket requires six arguments");
-	}
-
-	// TODO check arguments types
-
-	Napi::Object server = info[0].As<Napi::Object>();
-	Napi::Value client_ip = info[1].As<Napi::String>();
-	Napi::Function send_cb = info[2].As<Napi::Function>();
-	Napi::Function hs_cb = info[3].As<Napi::Function>();
-	Napi::Function error_cb = info[4].As<Napi::Function>();
-	Napi::Function resume_cb = info[5].As<Napi::Function>();
-
-	Napi::Object obj = constructor.New({ server, client_ip, send_cb, hs_cb, error_cb, resume_cb });
-
-	return scope.Escape(napi_value(obj)).ToObject();
-}
-
 Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
 	Napi::HandleScope scope(env);
@@ -185,10 +162,9 @@ DtlsSocket::DtlsSocket(const Napi::CallbackInfo& info) :
 		env(info.Env()) {
 	DtlsServer *server = Napi::ObjectWrap<DtlsServer>::Unwrap(info[0].As<Napi::Object>());
 	std::string client_ip = (std::string) info[1].As<Napi::String>();
-
 	send_cb = Napi::Persistent(info[2].As<Napi::Function>());
-	error_cb = Napi::Persistent(info[3].As<Napi::Function>());
-	handshake_cb = Napi::Persistent(info[4].As<Napi::Function>());
+	handshake_cb = Napi::Persistent(info[3].As<Napi::Function>());
+	error_cb = Napi::Persistent(info[4].As<Napi::Function>());
 	resume_sess_cb = Napi::Persistent(info[5].As<Napi::Function>());
 	session_wait = false;
 	recv_buf = nullptr;

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -66,12 +66,12 @@ Napi::Value DtlsSocket::ReceiveDataFromNode(const Napi::CallbackInfo& info) {
 		Napi::Buffer<unsigned char> recv_buffer = info[0].As<Napi::Buffer<unsigned char>>();
 		const unsigned char *recv_data = (unsigned char *) recv_buffer.Data();
 		size_t recv_len = recv_buffer.Length();
+		fprintf(stdout, "-------\n%d\n%x\n-------\n", recv_len, recv_data);
 		socket->store_data(recv_data, recv_len);
 	}
 
-	int len = 1024;
-	unsigned char buf[len];
-	len = socket->receive_data(buf, len);
+	unsigned char buf[RECV_BUF_LENGTH];
+	unsigned int len = socket->receive_data(buf, RECV_BUF_LENGTH);
 
 	return len > 0 ? Napi::Buffer<unsigned char>::Copy(env, buf, len) : env.Undefined();
 }
@@ -85,16 +85,16 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 		throw Napi::TypeError::New(env, "ssl_context.session was null");
 	}
 
-	unsigned char buf[KEYBUFF_LENGTH];
+	unsigned char buf[KEY_BUF_LENGTH];
 	mbedtls_pk_context pk = session->peer_cert->pk;
-	int ret = mbedtls_pk_write_pubkey_der(&pk, buf, KEYBUFF_LENGTH);
+	int ret = mbedtls_pk_write_pubkey_der(&pk, buf, KEY_BUF_LENGTH);
 
 	if (ret < 0) {
 		throw Napi::TypeError::New(env, "error at mbedtls_pk_write_pubkey_der");
 	}
 
 	// key is written at the end
-	return Napi::Buffer<char>::Copy(env, (char *)buf + (KEYBUFF_LENGTH - ret), ret);
+	return Napi::Buffer<char>::Copy(env, (char *)buf + (KEY_BUF_LENGTH - ret), ret);
 }
 
 Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
@@ -107,9 +107,9 @@ Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
 		throw Napi::TypeError::New(env, "ssl_context.session was null");
 	}
 
-	unsigned char buf[KEYBUFF_LENGTH];
+	unsigned char buf[KEY_BUF_LENGTH];
 	mbedtls_pk_context pk = session->peer_cert->pk;
-	int ret = mbedtls_pk_write_pubkey_pem(&pk, buf, KEYBUFF_LENGTH);
+	int ret = mbedtls_pk_write_pubkey_pem(&pk, buf, KEY_BUF_LENGTH);
 
 	if (ret < 0) {
 		throw Napi::TypeError::New(env, "error at mbedtls_pk_write_pubkey_pem");

--- a/src/DtlsSocket.cc
+++ b/src/DtlsSocket.cc
@@ -82,7 +82,7 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 
 	mbedtls_ssl_session *session = socket->ssl_context.session;
 	if (session == NULL) {
-		throw Napi::TypeError::New(env, "ssl_context.session was null");
+		return env.Undefined();
 	}
 
 	unsigned char buf[KEY_BUF_LENGTH];
@@ -90,7 +90,8 @@ Napi::Value DtlsSocket::GetPublicKey(const Napi::CallbackInfo& info) {
 	int ret = mbedtls_pk_write_pubkey_der(&pk, buf, KEY_BUF_LENGTH);
 
 	if (ret < 0) {
-		throw Napi::TypeError::New(env, "error at mbedtls_pk_write_pubkey_der");
+		// TODO error?
+		return env.Undefined();
 	}
 
 	// key is written at the end
@@ -102,9 +103,8 @@ Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
 	DtlsSocket *socket = Napi::ObjectWrap<DtlsSocket>::Unwrap(info.This().As<Napi::Object>());
 
 	mbedtls_ssl_session *session = socket->ssl_context.session;
-	if (session == NULL ||
-		session->peer_cert == NULL) {
-		throw Napi::TypeError::New(env, "ssl_context.session was null");
+	if (session == NULL || session->peer_cert == NULL) {
+		return env.Undefined();
 	}
 
 	unsigned char buf[KEY_BUF_LENGTH];
@@ -112,7 +112,8 @@ Napi::Value DtlsSocket::GetPublicKeyPEM(const Napi::CallbackInfo& info) {
 	int ret = mbedtls_pk_write_pubkey_pem(&pk, buf, KEY_BUF_LENGTH);
 
 	if (ret < 0) {
-		throw Napi::TypeError::New(env, "error at mbedtls_pk_write_pubkey_pem");
+		// TODO error?
+		return env.Undefined();
 	}
 
 	return Napi::Buffer<char>::Copy(env, (char *)buf, strlen((char *)buf));

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -16,7 +16,6 @@ class DtlsSocket : public Napi::ObjectWrap<DtlsSocket> {
 public:
 	static Napi::Value Initialize(Napi::Env& env, Napi::Object& target);
 	static Napi::Object New(const Napi::CallbackInfo& info);
-	inline void NopSet(const Napi::CallbackInfo& info, const Napi::Value& value) {}
 	Napi::Value ReceiveDataFromNode(const Napi::CallbackInfo& info);
 	Napi::Value Close(const Napi::CallbackInfo& info);
 	Napi::Value Send(const Napi::CallbackInfo& info);

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -54,7 +54,7 @@ private:
 	mbedtls_ssl_context ssl_context;
 	mbedtls_timing_delay_context timer;
 	mbedtls_ssl_config* ssl_config;
-	const unsigned char *recv_buf;
+	unsigned char *recv_buf;
 	size_t recv_len;
 	unsigned char *ip;
 	size_t ip_len;

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -29,9 +29,9 @@ public:
 	int send_encrypted(const unsigned char *buf, size_t len);
 	int recv(unsigned char *buf, size_t len);
 	int send(const unsigned char *buf, size_t len);
-	int receive_data(unsigned char *buf, int len);
+	int receive_data(unsigned char *buf, size_t len);
 	int step();
-	void store_data(const unsigned char *buf, size_t len);
+	int store_data(const unsigned char *buf, size_t len);
 	int close();
 	void error(int ret);
 	void reset();

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -1,8 +1,7 @@
 #ifndef __DTLS_SOCKET_H__
 #define __DTLS_SOCKET_H__
 
-#include <node.h>
-#include <nan.h>
+#include <napi.h>
 
 #include "mbedtls/ssl.h"
 #include "mbedtls/timing.h"
@@ -10,27 +9,21 @@
 #include "DtlsServer.h"
 #include "SessionWrap.h"
 
-class DtlsSocket : public Nan::ObjectWrap {
+class DtlsSocket : public Napi::ObjectWrap<DtlsSocket> {
 public:
-	static Nan::Persistent<v8::FunctionTemplate> constructor;
-	static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
-	static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static void ReceiveDataFromNode(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static void Send(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static void ResumeSession(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static void Renegotiate(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static NAN_GETTER(GetPublicKey);
-	static NAN_GETTER(GetPublicKeyPEM);
-	static NAN_GETTER(GetOutCounter);
-	static NAN_GETTER(GetSession);
-	DtlsSocket(DtlsServer *server,
-						 unsigned char *client_ip,
-						 size_t client_ip_len,
-						 Nan::Callback* send_callback,
-						 Nan::Callback* hs_callback,
-						 Nan::Callback* error_callback,
-						 Nan::Callback* resume_sess_callback);
+	static Napi::Value Initialize(Napi::Env& env, Napi::Object& target);
+	static Napi::Object New(const Napi::CallbackInfo& info);
+	inline void NopSet(const Napi::CallbackInfo& info, const Napi::Value& value) {}
+	Napi::Value ReceiveDataFromNode(const Napi::CallbackInfo& info);
+	Napi::Value Close(const Napi::CallbackInfo& info);
+	Napi::Value Send(const Napi::CallbackInfo& info);
+	Napi::Value ResumeSession(const Napi::CallbackInfo& info);
+	Napi::Value Renegotiate(const Napi::CallbackInfo& info);
+	Napi::Value GetPublicKey(const Napi::CallbackInfo& info);
+	Napi::Value GetPublicKeyPEM(const Napi::CallbackInfo& info);
+	Napi::Value GetOutCounter(const Napi::CallbackInfo& info);
+	Napi::Value GetSession(const Napi::CallbackInfo& info);
+	DtlsSocket(const Napi::CallbackInfo& info);
 	int send_encrypted(const unsigned char *buf, size_t len);
 	int recv(unsigned char *buf, size_t len);
 	int send(const unsigned char *buf, size_t len);
@@ -45,13 +38,16 @@ public:
 	bool resume(SessionWrap *sess);
 	void proceed();
 
-private:
-	void throwError(int ret);
 	~DtlsSocket();
-	Nan::Callback* send_cb;
-	Nan::Callback* error_cb;
-	Nan::Callback* handshake_cb;
-	Nan::Callback* resume_sess_cb;
+
+private:
+	Napi::Env env;
+	static Napi::FunctionReference constructor;
+	void throwError(int ret);
+	Napi::Function send_cb;
+	Napi::Function error_cb;
+	Napi::Function handshake_cb;
+	Napi::Function resume_sess_cb;
 	mbedtls_ssl_context ssl_context;
 	mbedtls_timing_delay_context timer;
 	mbedtls_ssl_config* ssl_config;
@@ -61,7 +57,7 @@ private:
 	size_t ip_len;
 
 	bool session_wait;
-	uint8_t random[64];	
+	uint8_t random[64];
 };
 
 #endif

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -9,6 +9,8 @@
 #include "DtlsServer.h"
 #include "SessionWrap.h"
 
+#define KEYBUFF_LENGTH 1024
+
 class DtlsSocket : public Napi::ObjectWrap<DtlsSocket> {
 public:
 	static Napi::Value Initialize(Napi::Env& env, Napi::Object& target);

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -9,7 +9,8 @@
 #include "DtlsServer.h"
 #include "SessionWrap.h"
 
-#define KEYBUFF_LENGTH 1024
+#define KEY_BUF_LENGTH 1024
+#define RECV_BUF_LENGTH 1024
 
 class DtlsSocket : public Napi::ObjectWrap<DtlsSocket> {
 public:

--- a/src/DtlsSocket.h
+++ b/src/DtlsSocket.h
@@ -47,10 +47,10 @@ private:
 	Napi::Env env;
 	static Napi::FunctionReference constructor;
 	void throwError(int ret);
-	Napi::Function send_cb;
-	Napi::Function error_cb;
-	Napi::Function handshake_cb;
-	Napi::Function resume_sess_cb;
+	Napi::FunctionReference send_cb;
+	Napi::FunctionReference error_cb;
+	Napi::FunctionReference handshake_cb;
+	Napi::FunctionReference resume_sess_cb;
 	mbedtls_ssl_context ssl_context;
 	mbedtls_timing_delay_context timer;
 	mbedtls_ssl_config* ssl_config;

--- a/src/SessionWrap.cc
+++ b/src/SessionWrap.cc
@@ -36,7 +36,7 @@ Napi::Object SessionWrap::CreateFromContext(Napi::Env env, mbedtls_ssl_context *
 	news->in_epoch = ssl->in_epoch;
 	memcpy(news->out_ctr, ssl->out_ctr, 8);
 
-	return instance;
+	return scope.Escape(instance).As<Napi::Object>();
 }
 
 Napi::Value SessionWrap::Restore(const Napi::CallbackInfo& info) {

--- a/src/SessionWrap.cc
+++ b/src/SessionWrap.cc
@@ -47,27 +47,34 @@ Napi::Value SessionWrap::Restore(const Napi::CallbackInfo& info) {
 	session->ciphersuite = object.Get("ciphersuite").As<Napi::Number>().Uint32Value();
 
 	Napi::Object rbv = object.Get("randbytes").ToObject();
-	memcpy(session->randbytes,
-		(rbv).As<Napi::Buffer<char>>().Data(),
-		(rbv).As<Napi::Buffer<char>>().Length());
+	size_t rbv_length = rbv.As<Napi::Buffer<char>>().Length();
+	if (rbv_length > RANDBYTES_LENGTH) {
+		throw Napi::RangeError::New(env, "random bytes value length greater than allowed");
+	}
+	memcpy(session->randbytes, (rbv).As<Napi::Buffer<char>>().Data(), rbv_length);
 
 	Napi::Object idv = object.Get("id").ToObject();
-	memcpy(session->id,
-		idv.As<Napi::Buffer<char>>().Data(),
-		idv.As<Napi::Buffer<char>>().Length());
-	session->id_len = (idv).As<Napi::Buffer<char>>().Length();
+	size_t idv_length = idv.As<Napi::Buffer<char>>().Length();
+	if (idv_length > ID_LENGTH) {
+		throw Napi::RangeError::New(env, "id value length greater than allowed");
+	}
+	memcpy(session->id, idv.As<Napi::Buffer<char>>().Data(), idv_length);
+	session->id_len = idv_length;
 
 	Napi::Object masterv = object.Get("master").ToObject();
-	memcpy(session->master,
-		masterv.As<Napi::Buffer<char>>().Data(),
-		masterv.As<Napi::Buffer<char>>().Length());
-
+	size_t masterv_length = rbv.As<Napi::Buffer<char>>().Length();
+	if (masterv_length > MASTER_LENGTH) {
+		throw Napi::RangeError::New(env, "master value length greater than allowed");
+	}
+	memcpy(session->master, masterv.As<Napi::Buffer<char>>().Data(), masterv_length);
 	session->in_epoch = object.Get("in_epoch").As<Napi::Number>().Uint32Value();
 
 	Napi::Object out_ctrv = object.Get("out_ctr").ToObject();
-	memcpy(session->out_ctr,
-		out_ctrv.As<Napi::Buffer<char>>().Data(),
-		out_ctrv.As<Napi::Buffer<char>>().Length());
+	size_t out_ctrv_length = rbv.As<Napi::Buffer<char>>().Length();
+	if (out_ctrv_length > OUT_CR_LENGTH) {
+		throw Napi::RangeError::New(env, "out_ctr value length greater than allowed");
+	}
+	memcpy(session->out_ctr, out_ctrv.As<Napi::Buffer<char>>().Data(), out_ctrv_length);
 
 	return Napi::Boolean::New(env, true);
 }

--- a/src/SessionWrap.cc
+++ b/src/SessionWrap.cc
@@ -25,9 +25,7 @@ Napi::Object SessionWrap::Initialize(Napi::Env& env, Napi::Object& exports) {
 
 Napi::Object SessionWrap::CreateFromContext(Napi::Env env, mbedtls_ssl_context *ssl, uint8_t *random) {
 	Napi::EscapableHandleScope scope(env);
-
-	Napi::Value arg;
-	Napi::Object instance = constructor.New({ arg });
+	Napi::Object instance = constructor.New({ });
 
 	SessionWrap *news = Napi::ObjectWrap<SessionWrap>::Unwrap(instance);
 	news->ciphersuite = ssl->session->ciphersuite;

--- a/src/SessionWrap.cc
+++ b/src/SessionWrap.cc
@@ -160,6 +160,8 @@ void SessionWrap::SetOutCounter(const Napi::CallbackInfo& info, const Napi::Valu
 }
 
 SessionWrap::SessionWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<SessionWrap>(info) {
+	Napi::Env env = info.Env();
+	Napi::HandleScope scope(env);
 }
 
 SessionWrap::~SessionWrap() {

--- a/src/SessionWrap.cc
+++ b/src/SessionWrap.cc
@@ -29,12 +29,12 @@ Napi::Object SessionWrap::CreateFromContext(Napi::Env env, mbedtls_ssl_context *
 
 	SessionWrap *news = Napi::ObjectWrap<SessionWrap>::Unwrap(instance);
 	news->ciphersuite = ssl->session->ciphersuite;
-	memcpy(news->randbytes, random, 64);
+	memcpy(news->randbytes, random, RANDBYTES_LENGTH);
 	memcpy(news->id, ssl->session->id, ssl->session->id_len);
 	news->id_len = ssl->session->id_len;
-	memcpy(news->master, ssl->session->master, 48);
+	memcpy(news->master, ssl->session->master, MASTER_LENGTH);
 	news->in_epoch = ssl->in_epoch;
-	memcpy(news->out_ctr, ssl->out_ctr, 8);
+	memcpy(news->out_ctr, ssl->out_ctr, OUT_CR_LENGTH);
 
 	return scope.Escape(instance).As<Napi::Object>();
 }

--- a/src/SessionWrap.h
+++ b/src/SessionWrap.h
@@ -5,9 +5,14 @@
 
 #include "mbedtls/ssl.h"
 
+#define ID_LENGTH 32
+#define MASTER_LENGTH 48
+#define RANDBYTES_LENGTH 64
+#define OUT_CR_LENGTH 8
+
 class SessionWrap : public Napi::ObjectWrap<SessionWrap> {
 public:
-	static Napi::Object Initialize(Napi::Env& env, Napi::Object& exports);	
+	static Napi::Object Initialize(Napi::Env& env, Napi::Object& exports);
 	static Napi::Object CreateFromContext(Napi::Env env, mbedtls_ssl_context *ssl, uint8_t *random);
 	Napi::Value Restore(const Napi::CallbackInfo& info);
 	Napi::Value GetCiphersuite(const Napi::CallbackInfo& info);
@@ -27,13 +32,13 @@ public:
 	~SessionWrap();
 
 	int ciphersuite;
-	unsigned char id[32];
+	unsigned char id[ID_LENGTH];
 	size_t id_len;
-	unsigned char master[48];
-	uint8_t randbytes[64];
+	unsigned char master[MASTER_LENGTH];
+	uint8_t randbytes[RANDBYTES_LENGTH];
 	uint16_t in_epoch;
-	unsigned char out_ctr[8];
-	
+	unsigned char out_ctr[OUT_CR_LENGTH];
+
 private:
 	static Napi::FunctionReference constructor;
 };

--- a/src/SessionWrap.h
+++ b/src/SessionWrap.h
@@ -1,30 +1,30 @@
 #ifndef __SESSION_WRAP_H__
 #define __SESSION_WRAP_H__
 
-#include <node.h>
-#include <nan.h>
+#include <napi.h>
 
 #include "mbedtls/ssl.h"
 
-class SessionWrap : public Nan::ObjectWrap {
+class SessionWrap : public Napi::ObjectWrap<SessionWrap> {
 public:
-	static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);	
-	static v8::Local<v8::Object> CreateFromContext(mbedtls_ssl_context *ssl, uint8_t *random);
-	static void Restore(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static NAN_GETTER(GetCiphersuite);
-	static NAN_GETTER(GetRandomBytes);
-	static NAN_GETTER(GetId);
-	static NAN_GETTER(GetMaster);
-	static NAN_GETTER(GetInEpoch);
-	static NAN_GETTER(GetOutCounter);
+	static Napi::Object Initialize(Napi::Env& env, Napi::Object& exports);	
+	static Napi::Object CreateFromContext(Napi::Env env, mbedtls_ssl_context *ssl, uint8_t *random);
+	Napi::Value Restore(const Napi::CallbackInfo& info);
+	Napi::Value GetCiphersuite(const Napi::CallbackInfo& info);
+	Napi::Value GetRandomBytes(const Napi::CallbackInfo& info);
+	Napi::Value GetId(const Napi::CallbackInfo& info);
+	Napi::Value GetMaster(const Napi::CallbackInfo& info);
+	Napi::Value GetInEpoch(const Napi::CallbackInfo& info);
+	Napi::Value GetOutCounter(const Napi::CallbackInfo& info);
 
-	static NAN_SETTER(SetCiphersuite);
-	static NAN_SETTER(SetRandomBytes);
-	static NAN_SETTER(SetId);
-	static NAN_SETTER(SetMaster);
-	static NAN_SETTER(SetInEpoch);
-	static NAN_SETTER(SetOutCounter);
-	SessionWrap();
+	void SetCiphersuite(const Napi::CallbackInfo& info, const Napi::Value& value);
+	void SetRandomBytes(const Napi::CallbackInfo& info, const Napi::Value& value);
+	void SetId(const Napi::CallbackInfo& info, const Napi::Value& value);
+	void SetMaster(const Napi::CallbackInfo& info, const Napi::Value& value);
+	void SetInEpoch(const Napi::CallbackInfo& info, const Napi::Value& value);
+	void SetOutCounter(const Napi::CallbackInfo& info, const Napi::Value& value);
+	SessionWrap(const Napi::CallbackInfo& info);
+	~SessionWrap();
 
 	int ciphersuite;
 	unsigned char id[32];
@@ -35,11 +35,7 @@ public:
 	unsigned char out_ctr[8];
 	
 private:
-	~SessionWrap();
-
-	static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
-	static Nan::Persistent<v8::FunctionTemplate> constructor;
-	
+	static Napi::FunctionReference constructor;
 };
 
 #endif

--- a/src/Untitled-1
+++ b/src/Untitled-1
@@ -1,5 +1,0 @@
-,
-        "src/SessionWrap.cc"
-        "src/DtlsServer.cc",
-        "src/DtlsSocket.cc",
-        

--- a/src/Untitled-1
+++ b/src/Untitled-1
@@ -1,0 +1,5 @@
+,
+        "src/SessionWrap.cc"
+        "src/DtlsServer.cc",
+        "src/DtlsSocket.cc",
+        

--- a/src/init.cc
+++ b/src/init.cc
@@ -1,12 +1,14 @@
+#include <napi.h>
 
 #include "DtlsServer.h"
 #include "DtlsSocket.h"
 #include "SessionWrap.h"
 
-NAN_MODULE_INIT(init) {
-	DtlsServer::Initialize(target);
-	DtlsSocket::Initialize(target);
-	SessionWrap::Initialize(target);
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+	DtlsServer::Initialize(env, exports);
+	DtlsSocket::Initialize(env, exports);
+	SessionWrap::Initialize(env, exports);
+	return exports;
 }
 
-NODE_MODULE(node_mbed_dtls, init);
+NODE_API_MODULE(node_mbed_dtls, init)

--- a/test/unit/DtlsServer.test.js
+++ b/test/unit/DtlsServer.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const path = require('path');
+const should = require('should');
+const sinon = require('sinon');
+const assert = require('assert');
+
+const mbed = require('bindings')('node_mbed_dtls.node');
+
+const opts = {
+	cert: path.join(__dirname, 'test/public.der'),
+	key: path.join(__dirname, 'test/private.der')
+};
+
+describe('DtlsServer', function() {
+
+});

--- a/test/unit/DtlsSocket.test.js
+++ b/test/unit/DtlsSocket.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const path = require('path');
+const should = require('should');
+const sinon = require('sinon');
+const assert = require('assert');
+
+const mbed = require('bindings')('node_mbed_dtls.node');
+
+const opts = {
+	cert: path.join(__dirname, 'test/public.der'),
+	key: path.join(__dirname, 'test/private.der')
+};
+
+describe('DtlsSocket', function() {
+
+});

--- a/test/unit/SessionWrap.test.js
+++ b/test/unit/SessionWrap.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const path = require('path');
+const should = require('should');
+const sinon = require('sinon');
+const assert = require('assert');
+
+const mbed = require('bindings')('node_mbed_dtls.node');
+
+const opts = {
+	cert: path.join(__dirname, 'test/public.der'),
+	key: path.join(__dirname, 'test/private.der')
+};
+
+describe('SessionWrap', function() {
+
+});


### PR DESCRIPTION
We use this as a dependency in a few of our node apps however, in an effort to upgrade our node version, I've found that this fails spectacularly as some of the conventions uses are no longer available under the versions of V8 post node 8 (i.e. node 10 and 12 have this issue). Sure, we could update it to work with higher versions of node, but to what end? NAN is being replaced by the official N-API which offers a guaranteed stable ABI that ensures maximum compatibility.

The primary focus of this is to get this compiling with node 10 and 12 as fast as possible by porting it to N-API using the node-addon-api package which offers an Object-based approach instead of the C-style napi_* functions. This allows us to use the same style everywhere as our prior implementation, a mix of V8 and NAN objects/macros.

Some other things that are not being addressed that need to:

* Better/full test coverage
* Use node crypto instead of the deterministic RNG included with mbed-dtls
* Consistent API from exported C++ objects (where is the line drawn between what we let JS handle vs the compiled portions?)
* Documentation and Examples