### PR TITLE
Allow devices to force re-handshake when the server is restarted

### DIFF
--- a/server.js
+++ b/server.js
@@ -156,7 +156,8 @@ class DtlsServer extends EventEmitter {
 							// Technically, the session has been moved successfully though, so we can now process queued messages
 							// which were received from the new device address
 							this._debug(`ipChanged not handled, ip=${key}`);
-							this._processMoveSessionMessages(key);
+							this._clearMoveSessionMessages(key);
+							this.emit('forceDeviceRehandshake', rinfo, deviceId);
 						}
 					} else {
 						this._debug(`handleIpChange: message not successfully received, NOT changing ip address fromip=${oldKey}, toip=${key}, deviceID=${deviceId}`);

--- a/server.js
+++ b/server.js
@@ -146,6 +146,7 @@ class DtlsServer extends EventEmitter {
 								this._processMoveSessionMessages(key);
 							} else {
 								this._clearMoveSessionMessages(key);
+								this.emit('forceDeviceRehandshake', rinfo, deviceId);
 							}
 						});
 						if (!updatePending) {


### PR DESCRIPTION
When the IP changed event has no event handler, we need to handle this more gracefully and optionally force handshake wth the device

forceDeviceRehandshake is controlled by a launchdarkly flag inside the Device Service, it helps specific customers sleepy devices reconnect after a device service deployment, pre 1.2.1

We should also clear out the move session messages as this can re-occur 