### PR TITLE
Add try/catch block to a call that throws sometimes

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -169,7 +169,17 @@ class DtlsSocket extends stream.Duplex {
 		}
 
 		this.emit('receive', (msg && msg.length) || 0);
-		const data = this.mbedSocket.receiveData(msg);
+		let data;
+
+		try {
+			// We keep getting an 'unknown error' thrown from this call
+			// but we cannot figure out where in the native code it is
+			// coming from.
+			data = this.mbedSocket.receiveData(msg);
+		} catch (error) {
+			this.server.emit('clientError', error, this);
+		}
+
 		if (data) {
 			this.push(data);
 			return true;


### PR DESCRIPTION
We discussed adding this here to be able to determine if we are getting client errors during a message receive.