### PR TITLE
Call _end() during this clientError

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -177,7 +177,11 @@ class DtlsSocket extends stream.Duplex {
 			// coming from.
 			data = this.mbedSocket.receiveData(msg);
 		} catch (error) {
-			this.server.emit('clientError', error, this);
+			// based on DTLS debug logs, this error is what mbed-tls should be giving us
+			// @TODO find a way to get this message from mbed-tls
+			this.server.emit('clientError', 'SSL - Verification of the message MAC failed', this);
+			this._hadError = true;
+			this._end();
 		}
 
 		if (data) {


### PR DESCRIPTION
We emit the `clientError` event and then we call _end() to terminate the socket which triggers a whole bunch of unreferencing. This is likely going fix some memory problems folks may have encountered.